### PR TITLE
offer a way to customize rundeck's JVM parameters easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ sudo docker run -p 4440:4440 -e SERVER_URL=http://MY.HOSTNAME.COM:4440 -t jordan
 ```
 SERVER_URL - Full URL in the form http://MY.HOSTNAME.COM:4440, http//123.456.789.012:4440, etc
 
+RDECK_JVM - Additional parameters sent to the rundeck JVM (ex: -Dserver.web.context=/rundeck)
+
 DATABASE_URL - For use with (container) external database
 
 RUNDECK_PASSWORD - MySQL 'rundeck' user password

--- a/content/opt/rundeck-defaults/profile
+++ b/content/opt/rundeck-defaults/profile
@@ -22,7 +22,7 @@ fi
 
 export CLI_CP=$(find /var/lib/rundeck/cli -name \*.jar -printf %p:)
 export BOOTSTRAP_CP=$(find /var/lib/rundeck/bootstrap -name \*.jar -printf %p:)
-export RDECK_JVM="-Djava.security.auth.login.config=/etc/rundeck/jaas-loginmodule.conf \
+export RDECK_JVM="${RDECK_JVM} -Djava.security.auth.login.config=/etc/rundeck/jaas-loginmodule.conf \
         -Dloginmodule.name=RDpropertyfilelogin \
         -Drdeck.config=/etc/rundeck \
         -Drdeck.base=/var/lib/rundeck \


### PR DESCRIPTION
I have added a new environment variable RDECK_JVM to allow fine customization of rundeck configuration without having to recompile.

This way, we can easily add an environment variable to set the context root and run rundeck behind a reverse proxy w/o having to rebuild the image.

Signed-off-by: Mathieu POUSSE <mathieu.pousse@zenika.com>