### PR TITLE
prefer a curl instead of ADD to enable use of docker build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV NO_LOCAL_MYSQL false
 
 RUN apt-get -qq update && apt-get -qqy upgrade && apt-get -qqy install --no-install-recommends bash supervisor procps sudo ca-certificates openjdk-7-jre-headless openssh-client mysql-server mysql-client pwgen curl git && apt-get clean
 
-ADD http://dl.bintray.com/rundeck/rundeck-deb/rundeck-2.6.4-1-GA.deb /tmp/rundeck.deb
+RUN curl -Lo /tmp/rundeck.deb http://dl.bintray.com/rundeck/rundeck-deb/rundeck-2.6.4-1-GA.deb
 
 ADD content/ /
 


### PR DESCRIPTION
Using ADD to retrieve the package by passes docker build cache. We can RUN a curl command that will get the binary.

That will enable the use of docker cache and dramatically improve the build time. If nothing changed in the context it is instant. If the rundeck release has been updated simply changing the file version will force to redownload 

BTW, maybe there is an obvious reason why you used ADD, let me know.