### PR TITLE
rundeck plugins may also be .zip files

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -132,6 +132,10 @@ update_user_password () {
       echo "=>Installing plugins from /opt/rundeck-plugins"
       cp /opt/rundeck-plugins/*.jar /var/lib/rundeck/libext 2>/dev/null
    fi
+   if ls /opt/rundeck-plugins/*.zip 1> /dev/null 2>&1; then
+      echo "=>Installing plugins from /opt/rundeck-plugins"
+      cp /opt/rundeck-plugins/*.zip /var/lib/rundeck/libext 2>/dev/null
+   fi
 
 echo -e "\n\n\n"
 echo "==================================================================="


### PR DESCRIPTION
Hi,

I was reading http://rundeck.org/docs/plugins-user-guide/installing.html

and it seems that we also need to copy .zip files