### PR TITLE
Make service.log owned by rundeck, not root

### DIFF
--- a/content/opt/supervisor/rundeck
+++ b/content/opt/supervisor/rundeck
@@ -20,7 +20,7 @@ function shutdown()
 
 echo -n "`date +"%d.%m.%Y %T.%3N"` - Starting ${prog}"
 cd /var/log/rundeck
-nohup su -s /bin/bash rundeck -c "$rundeckd" &>>/var/log/rundeck/service.log &
+nohup su -s /bin/bash rundeck -c "$rundeckd &>>/var/log/rundeck/service.log" &
 PID=$!
 echo $PID > $PIDFILE
 


### PR DESCRIPTION
Was getting the file service.log owned by root in the /var/log/rundeck directory.  The directory itself is owned by rundeck.  This change makes the files in /var/log/rundeck consistently owned by the rundeck account.