### PR TITLE
Overload the user and group ID for the rundeck account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ RDECK_JVM - Additional parameters sent to the rundeck JVM (ex: -Dserver.web.cont
 
 DATABASE_URL - For use with (container) external database
 
+RUNDECK_UID - The unix user ID to be used for the rundeck account when rundeck is booted.  This is useful for embedding this docker container into your development environment sharing files via docker volumes between the container and your host OS.  RUNDECK_GID also needs to be defined for this overload to take place.
+
+RUNDECK_GID - The unix group ID to be used for the rundeck account when rundeck is booted.  This is useful for embedding this docker container into your development environment sharing files via docker volumes between the container and your host OS.  RUNDECK_UID also needs to be defined for this overload to take place.
+
 RUNDECK_PASSWORD - MySQL 'rundeck' user password
 
 RUNDECK_STORAGE_PROVIDER - Options file (default) or db.  See: http://rundeck.org/docs/plugins-user-guide/configuring.html#storage-plugins

--- a/content/opt/run
+++ b/content/opt/run
@@ -6,6 +6,13 @@ initfile=/etc/rundeck.init
 
 chmod 1777 /tmp
 
+if [[ -n "\${RUNDECK_GID}" && -n "\${RUNDECK_UID}" ]]; then
+  echo "Setting rundeck account to \${RUNDECK_UID}:\${RUNDECK_GID}"
+  groupmod -o -g \${RUNDECK_GID} rundeck
+  usermod -o -u \${RUNDECK_UID} -g \${RUNDECK_GID} rundeck
+  rm -rf /tmp/rundeck
+fi
+
 # chown directories and files that might be coming from volumes
 chown -R mysql:mysql /var/lib/mysql
 chown -R rundeck:rundeck /etc/rundeck


### PR DESCRIPTION
I use this patch quite a bit to mount rundeck directories as docker volumes between my laptop and my container and get the file permissions to agree between the host OS and the docker image.