### PR TITLE
Add EXTERNAL_SERVER_URL configuration prameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To add (external) plugins, add the jars to the /opt/rundeck-plugins volume and t
 ```
 SERVER_URL - Full URL in the form http://MY.HOSTNAME.COM:4440, http//123.456.789.012:4440, etc
 
+EXTERNAL_SERVER_URL - Use this if you are running rundeck behind a proxy.  This is useful if you run rundeck through some kind of external network gateway/load balancer.
+
 RDECK_JVM - Additional parameters sent to the rundeck JVM (ex: -Dserver.web.context=/rundeck)
 
 DATABASE_URL - For use with (container) external database

--- a/content/opt/run
+++ b/content/opt/run
@@ -23,6 +23,7 @@ chown -R rundeck:rundeck /opt/rundeck-defaults
 
 if [ ! -f "${initfile}" ]; then
    SERVER_URL=${SERVER_URL:-"https://0.0.0.0:4443"}
+   EXTERNAL_SERVER_URL=${EXTERNAL_SERVER_URL:-"${SERVER_URL}"}
    SERVER_HOSTNAME=$(echo ${SERVER_URL} | awk -F/ '{print $3}' | awk -F: '{print $1}')
    SERVER_PROTO=$(echo ${SERVER_URL} | awk -F/ '{print $1}' | awk -F: '{print $1}')
    SERVER_PORT=$(echo ${SERVER_URL} | awk -F/ '{print $3}' | awk -F: '{print $2}')
@@ -105,7 +106,7 @@ update_user_password () {
       echo "=>NO_LOCAL_MYSQL set to true.  Skipping local MySQL setup"
    fi
 
-   sed -i 's,grails.serverURL\=.*,grails.serverURL\='${SERVER_URL}',g' /etc/rundeck/rundeck-config.properties
+   sed -i 's,grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_SERVER_URL}',g' /etc/rundeck/rundeck-config.properties
    sed -i 's,dataSource.dbCreate.*,,g' /etc/rundeck/rundeck-config.properties
    sed -i 's,dataSource.url = .*,dataSource.url = '${DATABASE_URL}',g' /etc/rundeck/rundeck-config.properties
    if grep -q dataSource.username /etc/rundeck/rundeck-config.properties ; then


### PR DESCRIPTION
This is useful if you run this container behind a elastic load balancer or other kind of network http gateway.

See http://rundeck.org/docs/administration/configuring-ssl.html#using-an-ssl-terminated-proxy