### PR TITLE
Add rundeck-cli to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ ENV NO_LOCAL_MYSQL false
 RUN apt-get -qq update && apt-get -qqy upgrade && apt-get -qqy install --no-install-recommends bash supervisor procps sudo ca-certificates openjdk-7-jre-headless openssh-client mysql-server mysql-client pwgen curl git && apt-get clean
 
 RUN curl -Lo /tmp/rundeck.deb http://dl.bintray.com/rundeck/rundeck-deb/rundeck-2.6.9-1-GA.deb
+RUN curl -Lo /tmp/rundeck-cli.deb https://github.com/rundeck/rundeck-cli/releases/download/v0.1.19/rundeck-cli_0.1.19-1_all.deb
 
 ADD content/ /
 
-RUN dpkg -i /tmp/rundeck.deb && rm /tmp/rundeck.deb
+RUN dpkg -i /tmp/rundeck*.deb && rm /tmp/rundeck*.deb
 RUN chown rundeck:rundeck /tmp/rundeck
 RUN chmod u+x /opt/run
 RUN mkdir -p /var/lib/rundeck/.ssh

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To add (external) plugins, add the jars to the /opt/rundeck-plugins volume and t
 ```
 SERVER_URL - Full URL in the form http://MY.HOSTNAME.COM:4440, http//123.456.789.012:4440, etc
 
-EXTERNAL_SERVER_URL - Use this if you are running rundeck behind a proxy.  This is useful if you run rundeck through some kind of external network gateway/load balancer.
+EXTERNAL_SERVER_URL - Use this if you are running rundeck behind a proxy.  This is useful if you run rundeck through some kind of external network gateway/load balancer.  Note that utilities like rd-jobs and rd-projects will no longer work and you will need to use the newer [rd](https://github.com/rundeck/rundeck-cli) command line utility.
 
 RDECK_JVM - Additional parameters sent to the rundeck JVM (ex: -Dserver.web.context=/rundeck)
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -23,7 +23,7 @@ chown -R rundeck:rundeck /opt/rundeck-defaults
 
 if [ ! -f "${initfile}" ]; then
    SERVER_URL=${SERVER_URL:-"https://0.0.0.0:4443"}
-   EXTERNAL_SERVER_URL=${EXTERNAL_SERVER_URL:-"${SERVER_URL}"}
+   EXTERNAL_URL=${EXTERNAL_SERVER_URL:-"${SERVER_URL}"}
    SERVER_HOSTNAME=$(echo ${SERVER_URL} | awk -F/ '{print $3}' | awk -F: '{print $1}')
    SERVER_PROTO=$(echo ${SERVER_URL} | awk -F/ '{print $1}' | awk -F: '{print $1}')
    SERVER_PORT=$(echo ${SERVER_URL} | awk -F/ '{print $3}' | awk -F: '{print $2}')
@@ -106,7 +106,7 @@ update_user_password () {
       echo "=>NO_LOCAL_MYSQL set to true.  Skipping local MySQL setup"
    fi
 
-   sed -i 's,grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_SERVER_URL}',g' /etc/rundeck/rundeck-config.properties
+   sed -i 's,grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_URL}',g' /etc/rundeck/rundeck-config.properties
    sed -i 's,dataSource.dbCreate.*,,g' /etc/rundeck/rundeck-config.properties
    sed -i 's,dataSource.url = .*,dataSource.url = '${DATABASE_URL}',g' /etc/rundeck/rundeck-config.properties
    if grep -q dataSource.username /etc/rundeck/rundeck-config.properties ; then
@@ -127,11 +127,21 @@ update_user_password () {
    sed -i 's,framework.server.url\ \=.*,framework.server.url\ \=\ '${SERVER_URL}',g' /etc/rundeck/framework.properties
 
    # if the admin pwd is still the default password and RUNDECK_ADMIN_PASSWORD is defined
-   if [[ -n "${RUNDECK_ADMIN_PASSWORD}" && $( grep --silent '^admin:admin,' /etc/rundeck/realm.properties ) ]]; then
+   if $(grep --silent '^admin:admin,' /etc/rundeck/realm.properties) && [[ -n "${RUNDECK_ADMIN_PASSWORD}" ]]; then
       sed -i \
          's,framework.server.password\ \=.*,framework.server.password\ \=\ '${RUNDECK_ADMIN_PASSWORD}',g' \
          /etc/rundeck/framework.properties
       sed -i 's*^admin:admin,*admin:'${RUNDECK_ADMIN_PASSWORD}',*g' /etc/rundeck/realm.properties
+      # If EXTERNAL_SERVER_URL is being used, the inside/outside ports for rundeck confuse the standard
+      # CLI tools like rd-jobs, rd-project and they won't work.  You will need to use the new and improved
+      # rundeck-cli tools.  To make the new CLI tools easier to use, go ahead and add an API token for the
+      # admin account as a hash of the admin password.
+      if [[ -n "${EXTERNAL_SERVER_URL}" ]]; then
+        echo "rundeck.tokens.file=/etc/rundeck/tokens.properties" >> /etc/rundeck/framework.properties
+        mytoken=$(printf '%s' "${RUNDECK_ADMIN_PASSWORD}" | md5sum | cut -d ' ' -f 1)
+        echo "admin:${mytoken}" >> /etc/rundeck/tokens.properties
+        chown rundeck:rundeck /etc/rundeck/tokens.properties
+      fi
    fi
 
    if [ "${RUNDECK_STORAGE_PROVIDER}" == "db" ]; then

--- a/content/opt/run
+++ b/content/opt/run
@@ -137,9 +137,13 @@ update_user_password () {
       # rundeck-cli tools.  To make the new CLI tools easier to use, go ahead and add an API token for the
       # admin account as a hash of the admin password.
       if [[ -n "${EXTERNAL_SERVER_URL}" ]]; then
-        echo "rundeck.tokens.file=/etc/rundeck/tokens.properties" >> /etc/rundeck/framework.properties
+        grep --silent "rundeck\.tokens\.file" /etc/rundeck/framework.properties || \
+          echo "rundeck.tokens.file=/etc/rundeck/tokens.properties" >> /etc/rundeck/framework.properties
         mytoken=$(printf '%s' "${RUNDECK_ADMIN_PASSWORD}" | md5sum | cut -d ' ' -f 1)
-        echo "admin: ${mytoken}" >> /etc/rundeck/tokens.properties
+        [[ -e /etc/rundeck/tokens.properties ]] \
+          && grep --silent "^admin:" /etc/rundeck/tokens.properties \
+          && sed -i -e "s,^admin:.*,admin: ${mytoken},g" /etc/rundeck/tokens.properties \
+          || echo "admin: ${mytoken}" >> /etc/rundeck/tokens.properties
         chown rundeck:rundeck /etc/rundeck/tokens.properties
       fi
    fi

--- a/content/opt/run
+++ b/content/opt/run
@@ -139,7 +139,7 @@ update_user_password () {
       if [[ -n "${EXTERNAL_SERVER_URL}" ]]; then
         echo "rundeck.tokens.file=/etc/rundeck/tokens.properties" >> /etc/rundeck/framework.properties
         mytoken=$(printf '%s' "${RUNDECK_ADMIN_PASSWORD}" | md5sum | cut -d ' ' -f 1)
-        echo "admin:${mytoken}" >> /etc/rundeck/tokens.properties
+        echo "admin: ${mytoken}" >> /etc/rundeck/tokens.properties
         chown rundeck:rundeck /etc/rundeck/tokens.properties
       fi
    fi


### PR DESCRIPTION
When running jordan/rundeck in front of a load balancer using EXTERNAL_SERVER_URL, the rd-jobs and rd-projects CLI utilities break.  The rundeck devs recommend the newer [rd](https://github.com/rundeck/rundeck-cli) rundeck-cli which is a rewrite of the Rundeck CLI.  This pull request integrates this new debian into the docker image.