### PR TITLE
Adding support to configure remote mysql connections

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -118,7 +118,7 @@ if [ ! -f "${initfile}" ]; then
    else
       echo "=>NO_LOCAL_MYSQL set to true.  Skipping local MySQL setup"
       if [[ ${DATABASE_URL} == *"mysql"* ]]; then
-        echo "=>Initializing remote MySQL"
+        echo "=>Initializing remote MySQL setup"
         (
          echo "CREATE DATABASE IF NOT EXISTS rundeckdb;"
          echo "GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, CREATE VIEW, ALTER, INDEX, EXECUTE ON rundeckdb.* TO 'rundeck'@'localhost' IDENTIFIED BY '${RUNDECK_PASSWORD}';"

--- a/content/opt/run
+++ b/content/opt/run
@@ -117,6 +117,17 @@ if [ ! -f "${initfile}" ]; then
      cat /opt/mysql.conf >> /etc/supervisor/conf.d/rundeck.conf
    else
       echo "=>NO_LOCAL_MYSQL set to true.  Skipping local MySQL setup"
+      if [[ ${DATABASE_URL} == *"mysql"* ]]; then
+        echo "=>Initializing remote MySQL"
+        (
+         echo "CREATE DATABASE IF NOT EXISTS rundeckdb;"
+         echo "GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, CREATE VIEW, ALTER, INDEX, EXECUTE ON rundeckdb.* TO 'rundeck'@'localhost' IDENTIFIED BY '${RUNDECK_PASSWORD}';"
+         echo "quit"
+         ) |
+         mysql --host=$(echo ${DATABASE_URL} | grep -oP "(?<=jdbc:mysql:\/\/)(.*)(?=\/)") --user=rundek --password=${RUNDECK_PASSWORD}
+      else
+        echo "=>Remote database is not MySQL. Skipping remote setup"
+      fi
    fi
 
    sed -i 's,grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_URL}',g' /etc/rundeck/rundeck-config.properties

--- a/content/opt/run
+++ b/content/opt/run
@@ -124,7 +124,7 @@ if [ ! -f "${initfile}" ]; then
          echo "GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, CREATE VIEW, ALTER, INDEX, EXECUTE ON rundeckdb.* TO 'rundeck'@'localhost' IDENTIFIED BY '${RUNDECK_PASSWORD}';"
          echo "quit"
          ) |
-         mysql --host=$(echo ${DATABASE_URL} | grep -oP "(?<=jdbc:mysql:\/\/)(.*)(?=\/)") --user=rundek --password=${RUNDECK_PASSWORD}
+         mysql --host=$(echo ${DATABASE_URL} | grep -oP "(?<=jdbc:mysql:\/\/)(.*)(?=\/)") --user=rundeck --password=${RUNDECK_PASSWORD}
       else
         echo "=>Remote database is not MySQL. Skipping remote setup"
       fi


### PR DESCRIPTION
Hi,

We've added support to configure remote mysql connections to the base image.

There's probably a better more DRY way to achieve this but for now we just wanted something to work with our kubernetes cluster with a remote RDS DB.

It also assumes the remote db user to be `rundeck`.