### PR TITLE
Set brand via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ RUNDECK_STORAGE_PROVIDER - Options file (default) or db.  See: http://rundeck.or
 
 RUNDECK_PROJECT_STORAGE_TYPE - Options file (default) or db.  See: http://rundeck.org/docs/administration/setting-up-an-rdb-datasource.html
 
+GUI_BRAND_HTML - HTML to show as title in app header. See: http://rundeck.org/docs/administration/gui-customization.html. Useful to show Rundeck environment where multiple Rundeck instances are deployed, e.g. GUI_BRAND_HTML='<span class="title">QA Environment</span>'
+
 DEBIAN_SYS_MAINT_PASSWORD
 
 NO_LOCAL_MYSQL - false (default).  Set to true if using an external MySQL container or instance.  Make sure to set DATABASE_URL and RUNDECK_PASSWORD (used for JDBC connection to MySQL).  Further details for setting up MYSQL: http://rundeck.org/docs/administration/setting-up-an-rdb-datasource.html

--- a/content/opt/run
+++ b/content/opt/run
@@ -145,7 +145,16 @@ if [ ! -f "${initfile}" ]; then
    else
       echo "dataSource.password = ${RUNDECK_PASSWORD}" >> /etc/rundeck/rundeck-config.properties
    fi
-
+   
+   # Check if we need to set the rundeck.gui.brand.html property
+   if [ -n "${GUI_BRAND_HTML}" ]; then
+      if grep -q rundeck.gui.brand.html /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/rundeck\.gui\.brand\.html.*$/rundeck\.gui\.brand\.html = '${GUI_BRAND_HTML}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "rundeck.gui.brand.html = ${GUI_BRAND_HTML}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi
+   
    # framework.properties
    sed -i 's,framework.server.name\ \=.*,framework.server.name\ \=\ '${SERVER_HOSTNAME}',g' /etc/rundeck/framework.properties
    sed -i 's,framework.server.hostname\ \=.*,framework.server.hostname\ \=\ '${SERVER_HOSTNAME}',g' /etc/rundeck/framework.properties


### PR DESCRIPTION
This pull request allows setting of the Rundeck app header title text by including a new environment variable GUI_BRAND_HTML in the /opt/run script.

Additions to the run script include:
* Checks if the GUI_BRAND_HTML variable is set.
  * If GUI_BRAND_HTML is set, check if the property already exists in the file
    * If the property already exists in the file then use sed to replace with GUI_BRAND_HTML
  * Else if the property does not exist in the file use echo to append to the file

Additions to the README.md include:
* Description of the new environment variable
* A link to the relevant Rundeck documentation
* A simple example

Escaping of the HTML depends on how the container is run, from the command line with docker run the HTML will need to be quoted like any other environment variable e.g. 
```bash
docker run -e GUI_BRAND_HTML='<span class="hello">My Title</span>'
```
In a docker-compose file it will not necessary.