### PR TITLE
Don't hard-code port at startup

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -81,7 +81,8 @@ if [ ! -f "${initfile}" ]; then
    if [ ! -f /etc/rundeck/ssl/truststore ]; then
        echo "=>Generating ssl cert"
        sudo -u rundeck mkdir -p /etc/rundeck/ssl
-       sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass adminadmin -storepass adminadmin -dname "cn=localhost, o=OME, c=DE" && \
+       sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass ${KEYSTORE_PASS} -storepass ${TRUSTSTORE_PASS} -dname "cn=localhost, o=OME, c=DE"
+       sudo -u rundeck keytool -importkeystore -destkeystore ${DM_BASE_CFG_PATH}/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit
        cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
    fi
 

--- a/content/opt/supervisor/rundeck
+++ b/content/opt/supervisor/rundeck
@@ -9,7 +9,7 @@
 prog="rundeckd"
 PIDFILE=/var/run/$prog.pid
 DAEMON="${JAVA_HOME:-/usr}/bin/java"
-DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck 4440"
+DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck ${SERVER_PORT}"
 rundeckd="$DAEMON $DAEMON_ARGS"
 
 function shutdown()

--- a/content/opt/supervisor/rundeck
+++ b/content/opt/supervisor/rundeck
@@ -9,7 +9,7 @@
 prog="rundeckd"
 PIDFILE=/var/run/$prog.pid
 DAEMON="${JAVA_HOME:-/usr}/bin/java"
-DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck ${SERVER_PORT}"
+DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck 4440"
 rundeckd="$DAEMON $DAEMON_ARGS"
 
 function shutdown()


### PR DESCRIPTION
Currently, even with SERVER_PORT or anything else enabled, you are still starting Rundeck on port `4440`. This change uses SERVER_PORT instead, which you already set rather carefully during setup.