### PR TITLE
Import CA certs to new keystore

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -81,8 +81,10 @@ if [ ! -f "${initfile}" ]; then
    if [ ! -f /etc/rundeck/ssl/truststore ]; then
        echo "=>Generating ssl cert"
        sudo -u rundeck mkdir -p /etc/rundeck/ssl
+       if [ ! -f /etc/rundeck/ssl/keystore ]; then
+           sudo -u rundeck keytool -importkeystore -destkeystore /etc/rundeck/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit -noprompt > /dev/null
+       fi
        sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass ${KEYSTORE_PASS} -storepass ${TRUSTSTORE_PASS} -dname "cn=localhost, o=OME, c=DE"
-       sudo -u rundeck keytool -importkeystore -destkeystore /etc/rundeck/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit -noprompt > /dev/null
        cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
    fi
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -82,7 +82,7 @@ if [ ! -f "${initfile}" ]; then
        echo "=>Generating ssl cert"
        sudo -u rundeck mkdir -p /etc/rundeck/ssl
        sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass ${KEYSTORE_PASS} -storepass ${TRUSTSTORE_PASS} -dname "cn=localhost, o=OME, c=DE"
-       sudo -u rundeck keytool -importkeystore -destkeystore ${DM_BASE_CFG_PATH}/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit
+       sudo -u rundeck keytool -importkeystore -destkeystore /etc/rundeck/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit > /dev/null
        cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
    fi
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -53,7 +53,7 @@ if [ ! -f "${initfile}" ]; then
    LOGIN_MODULE=${LOGIN_MODULE:-"RDpropertyfilelogin"}
    JAAS_CONF_FILE=${JAAS_CONF_FILE:-"jaas-loginmodule.conf"}
    KEYSTORE_PASS=${KEYSTORE_PASS:-"adminadmin"}
-   TRUSTSTORE_PASS=${TRUSTSTORE_PASS:-"adminadmin"}
+   TRUSTSTORE_PASS=${TRUSTSTORE_PASS:-${KEYSTORE_PASS}}
 
    update_user_password () {
       (
@@ -81,7 +81,8 @@ if [ ! -f "${initfile}" ]; then
    if [ ! -f /etc/rundeck/ssl/truststore ]; then
        echo "=>Generating ssl cert"
        sudo -u rundeck mkdir -p /etc/rundeck/ssl
-       sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass adminadmin -storepass adminadmin -dname "cn=localhost, o=OME, c=DE" && \
+       sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass ${KEYSTORE_PASS} -storepass ${TRUSTSTORE_PASS} -dname "cn=localhost, o=OME, c=DE"
+       sudo -u rundeck keytool -importkeystore -destkeystore ${DM_BASE_CFG_PATH}/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit
        cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
    fi
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -82,7 +82,7 @@ if [ ! -f "${initfile}" ]; then
        echo "=>Generating ssl cert"
        sudo -u rundeck mkdir -p /etc/rundeck/ssl
        sudo -u rundeck keytool -keystore /etc/rundeck/ssl/keystore -alias rundeck -genkey -keyalg RSA -keypass ${KEYSTORE_PASS} -storepass ${TRUSTSTORE_PASS} -dname "cn=localhost, o=OME, c=DE"
-       sudo -u rundeck keytool -importkeystore -destkeystore /etc/rundeck/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit > /dev/null
+       sudo -u rundeck keytool -importkeystore -destkeystore /etc/rundeck/ssl/keystore -srckeystore /etc/ssl/certs/java/cacerts -deststoretype JKS -srcstoretype JKS -deststorepass ${TRUSTSTORE_PASS} -srcstorepass changeit -noprompt > /dev/null
        cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
    fi
 


### PR DESCRIPTION
We should import CA certs to the keystore created so Java can actually verify external certs (for things like the EC2 node clasifier).