### PR TITLE
Allow rundeck SMTP settings to be configured from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ RUNDECK_PROJECT_STORAGE_TYPE - Options file (default) or db.  See: http://rundec
 
 GUI_BRAND_HTML - HTML to show as title in app header. See: http://rundeck.org/docs/administration/gui-customization.html. Useful to show Rundeck environment where multiple Rundeck instances are deployed, e.g. GUI_BRAND_HTML='<span class="title">QA Environment</span>'
 
+SMTP_HOST - The SMTP server host to use for email notifications.
+
+SMTP_PORT - THe SMTP server port to use for email notifications.
+
+SMTP_USERNAME - The SMTP server username to use for email notifications if authentication is required.
+
+SMTP_PASSWORD - The SMTP server password to use for email notifications if authentication is required
+
+SMTP_DEFAULT_FROM - The from address to use for email notifications.
+
 DEBIAN_SYS_MAINT_PASSWORD - No longer used as of Debian Stretch
 
 NO_LOCAL_MYSQL - false (default).  Set to true if using an external MySQL container or instance.  Make sure to set DATABASE_URL and RUNDECK_PASSWORD (used for JDBC connection to MySQL).  Further details for setting up MYSQL: http://rundeck.org/docs/administration/setting-up-an-rdb-datasource.html

--- a/content/opt/run
+++ b/content/opt/run
@@ -146,6 +146,51 @@ if [ ! -f "${initfile}" ]; then
       fi
    fi
    
+   # Check if we need to set the grails.mail.host property
+   if [ -n "${SMTP_HOST}" ]; then
+      if grep -q grails.mail.host /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/grails\.mail\.host.*$/grails\.mail\.host = '${SMTP_HOST}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "grails.mail.host = ${SMTP_HOST}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi
+
+   # Check if we need to set the grails.mail.port property
+   if [ -n "${SMTP_PORT}" ]; then
+      if grep -q grails.mail.port /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/grails\.mail\.port.*$/grails\.mail\.port = '${SMTP_PORT}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "grails.mail.port = ${SMTP_PORT}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi
+
+   # Check if we need to set the grails.mail.username property
+   if [ -n "${SMTP_USERNAME}" ]; then
+      if grep -q grails.mail.username /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/grails\.mail\.username.*$/grails\.mail\.username = '${SMTP_USERNAME}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "grails.mail.username = ${SMTP_USERNAME}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi
+
+   # Check if we need to set the grails.mail.password property
+   if [ -n "${SMTP_PASSWORD}" ]; then
+      if grep -q grails.mail.password /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/grails\.mail\.password.*$/grails\.mail\.password = '${SMTP_PASSWORD}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "grails.mail.password = ${SMTP_PASSWORD}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi
+
+   # Check if we need to set the grails.mail.default.from property
+   if [ -n "${SMTP_DEFAULT_FROM}" ]; then
+      if grep -q grails.mail.default.from /etc/rundeck/rundeck-config.properties ; then
+        sed -i 's/grails\.mail\.default\.from.*$/grails\.mail\.default\.from = '${SMTP_DEFAULT_FROM}'/g' /etc/rundeck/rundeck-config.properties
+      else
+        echo "grails.mail.default.from = ${SMTP_DEFAULT_FROM}" >> /etc/rundeck/rundeck-config.properties
+      fi
+   fi 
+   
    # framework.properties
    sed -i 's,framework.server.name\ \=.*,framework.server.name\ \=\ '${SERVER_HOSTNAME}',g' /etc/rundeck/framework.properties
    sed -i 's,framework.server.hostname\ \=.*,framework.server.hostname\ \=\ '${SERVER_HOSTNAME}',g' /etc/rundeck/framework.properties


### PR DESCRIPTION
Hi,

This pull request deals with allowing configuration of rundeck email notification settings from environment variables.

It adds:
**SMTP_HOST** - The SMTP server host to use for email notifications.
**SMTP_PORT** - THe SMTP server port to use for email notifications.
**SMTP_USERNAME** - The SMTP server username to use for email notifications if authentication is required.
**SMTP_PASSWORD** - The SMTP server password to use for email notifications if authentication is required
**SMTP_DEFAULT_FROM** - The from address to use for email notifications.

I have updated the readme as well as the run script. 