### PR TITLE
Substitute grails.serverURL even if it was not commented out.

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -139,7 +139,7 @@ if [ ! -f "${initfile}" ]; then
 
   if ! [ -z "${EXTERNAL_SERVER_URL}" ]; then
     # if external_server_url is specified, write it in
-    sed -i 's,#grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_SERVER_URL}',g' /etc/rundeck/rundeck-config.properties
+    sed -i 's,#\?grails.serverURL\=.*,grails.serverURL\='${EXTERNAL_SERVER_URL}',g' /etc/rundeck/rundeck-config.properties
   fi
 
    sed -i 's,dataSource.dbCreate.*,,g' /etc/rundeck/rundeck-config.properties


### PR DESCRIPTION
The original rundeck.properties file of rundeck-2.10.1-1 has direct (not commented out) "grails.serverURL" line.