### PR TITLE
Fix JAAS auth

### DIFF
--- a/content/opt/rundeck-defaults/profile
+++ b/content/opt/rundeck-defaults/profile
@@ -34,7 +34,8 @@ RDECK_JVM_SETTINGS="${RDECK_JVM_SETTINGS:- -Xmx1024m -Xms256m -XX:MaxMetaspaceSi
 RDECK_TRUSTSTORE_FILE="${RDECK_TRUSTSTORE_FILE:-$RDECK_CONFIG/ssl/truststore}"
 RDECK_TRUSTSTORE_TYPE="${RDECK_TRUSTSTORE_TYPE:-jks}"
 JAAS_LOGIN="${JAAS_LOGIN:-true}"
-JAAS_CONF="${JAAS_CONF:-$RDECK_CONFIG/jaas-loginmodule.conf}"
+JAAS_CONF_FILE="${JAAS_LOGIN_CONF:-jaas-loginmodule.conf}"
+JAAS_CONF="${JAAS_CONF:-$RDECK_CONFIG/$JAAS_CONF_FILE}"
 LOGIN_MODULE="${LOGIN_MODULE:-RDpropertyfilelogin}"
 RDECK_HTTP_PORT=${RDECK_HTTP_PORT:-4440}
 RDECK_HTTPS_PORT=${RDECK_HTTPS_PORT:-4443}
@@ -58,7 +59,7 @@ for war in $(find $RDECK_INSTALL/bootstrap -name '*.war') ; do
 done
 
 RDECK_JVM="-Drundeck.jaaslogin=$JAAS_LOGIN \
-           -Dloginmodule.conf.name=$JAAS_CONF \
+           -Dloginmodule.conf.name=$JAAS_CONF_FILE \
            -Dloginmodule.name=$LOGIN_MODULE \
            -Drdeck.config=$RDECK_CONFIG \
            -Drundeck.server.configDir=$RDECK_SERVER_CONFIG \


### PR DESCRIPTION
Based on the following link the loginmodule.conf.name should point to
just the conf file instead of the full path to the file.

https://github.com/rundeck/rundeck/issues/3755

I also have https://github.com/rundeck/rundeck/pull/3783 to fix the package default.   Since I mount the loginmodule, when the run command detects if it should lay down the rundeck-defaults /etc/rundeck is not empty so it doesn't.

I created a branch that has this file in content/etc/rundeck so it overrides the default and that setup is currently working for me.