### PR TITLE
Change ownership only for files not owned by mysql/rundeck.

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -13,13 +13,11 @@ if [[ -n "${RUNDECK_GID}" && -n "${RUNDECK_UID}" ]]; then
 fi
 
 # chown directories and files that might be coming from volumes
-chown -R mysql:mysql /var/lib/mysql
-chown -R rundeck:rundeck /etc/rundeck
-chown -R rundeck:rundeck /var/rundeck
-chown -R rundeck:adm /var/log/rundeck
-chown -R rundeck:rundeck /var/lib/rundeck
-chown -R rundeck:rundeck /opt/rundeck-defaults
-chown -R rundeck:rundeck /tmp/rundeck
+find /var/lib/mysql \
+  \! -user mysql -exec chown -R mysql:mysql {} \;
+find /etc/rundeck /var/rundeck /var/log/rundeck \
+  /var/lib/rundeck /opt/rundeck-defaults /tmp/rundeck \
+  \! -user rundeck -exec chown -R rundeck:rundeck {} \;
 chmod -R 750 /tmp/rundeck
 
 # Plugins


### PR DESCRIPTION
 As discussed. Fixes #145

Can be tested by creating a config and referencing it by a docker service
```shell
# create config
echo bla| docker config create config -

# create service
docker service create  --name rundeck -p 4440:4440  --config source=config,target=/etc/rundeck/config,uid=101,gid=104 -e EXTERNAL_SERVER_URL=http://localhost:4440 jordan/rundeck
```