### PR TITLE
escape & in jdbc url options

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -177,7 +177,7 @@ if [ ! -f "${initfile}" ]; then
   fi
 
    sed -i 's,dataSource.dbCreate.*,,g' /etc/rundeck/rundeck-config.properties
-   sed -i 's,dataSource.url = .*,dataSource.url = '${DATABASE_URL}',g' /etc/rundeck/rundeck-config.properties
+   sed -i 's,dataSource.url = .*,dataSource.url = '${DATABASE_URL//\&/\\\&}',g' /etc/rundeck/rundeck-config.properties
    if grep -q dataSource.driverClassName /etc/rundeck/rundeck-config.properties ; then
       sed -i 's,dataSource.driverClassName = .*,dataSource.driverClassName = '${DATABASE_DRIVER}',g' /etc/rundeck/rundeck-config.properties
    else


### PR DESCRIPTION
When passing JDBC options in url, for example `…/rundeck?serverTimezone=UTC&sslMode=DISABLED`, the `&` is interpreted as the replacement character by `sed`.

This patch escape the `&`.