### PR TITLE
Upgrade Rundeck to 3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,15 @@ ENV SERVER_URL=https://localhost:4443 \
 RUN export DEBIAN_FRONTEND=noninteractive && \
     echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list && \
     apt-get -qq update && \
-    apt-get -qqy install -t stretch-backports --no-install-recommends bash openjdk-8-jre-headless ca-certificates-java supervisor procps sudo ca-certificates openssh-client mysql-server mysql-client postgresql-9.6 postgresql-client-9.6 pwgen curl git uuid-runtime parallel jq && \
+    apt-get -qqy install -t stretch-backports --no-install-recommends apt-transport-https curl ca-certificates && \
+    curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=10.5 && \
+    apt-get -qqy install -t stretch-backports --no-install-recommends bash openjdk-8-jre-headless ca-certificates-java supervisor procps sudo openssh-client mariadb-server mariadb-client postgresql-9.6 postgresql-client-9.6 pwgen git uuid-runtime parallel jq && \
     cd /tmp/ && \
-    curl -Lo /tmp/rundeck.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck_3.3.12.20210521-1_all.deb/download.deb && \
-    echo 'f404f379ce56a719e61f23487a781343847931b69ef128e16ae4ffdb0b7d40a6  rundeck.deb' > /tmp/rundeck.sig && \
+    curl -Lo /tmp/rundeck.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck_3.4.0.20210614-1_all.deb/download.deb && \
+    echo 'a0989a78850e38a7557d6603bd254495506d086b3e75f8356f3354a27a5fa1d8  rundeck.deb' > /tmp/rundeck.sig && \
     shasum -a256 -c /tmp/rundeck.sig && \
-    curl -Lo /tmp/rundeck-cli.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck-cli_1.3.4-1_all.deb/download.deb && \
-    echo '0abcf3a2166400aa15e428d2ecdae272f9b2b5d536d0231cf95ad64eb2fc6662  rundeck-cli.deb' > /tmp/rundeck-cli.sig && \
+    curl -Lo /tmp/rundeck-cli.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck-cli_1.3.10-1_all.deb/download.deb && \
+    echo 'e9f6fb2cd051b32b452a055ce5aa7e354b21e011a9c00c76e3d624c2338a3736  rundeck-cli.deb' > /tmp/rundeck-cli.sig && \
     shasum -a256 -c /tmp/rundeck-cli.sig && \
     cd - && \
     dpkg -i /tmp/rundeck*.deb && rm /tmp/rundeck*.deb && \

--- a/content/opt/run
+++ b/content/opt/run
@@ -109,11 +109,11 @@ if [ ! -f "${initfile}" ]; then
    if [ "${NO_LOCAL_MYSQL}" == "false" ]; then
       echo "=>Initializing local MySQL..."
       if [ "$(ls -A1 /var/lib/mysql|grep -v lost+found)" ]; then
-         /etc/init.d/mysql start
+         /etc/init.d/mariadb start
       else
          echo "=>MySQL datadir is empty...initializing"
          /usr/bin/mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
-         /etc/init.d/mysql start
+         /etc/init.d/mariadb start
      fi
 
      (
@@ -123,7 +123,7 @@ if [ ! -f "${initfile}" ]; then
      ) |
      mysql
      sleep 5
-     /etc/init.d/mysql stop
+     /etc/init.d/mariadb stop
      # Add MySQL to supervisord conf
      cat /opt/mysql.conf >> /etc/supervisor/conf.d/rundeck.conf
    else

--- a/content/opt/supervisor/mysql_supervisor
+++ b/content/opt/supervisor/mysql_supervisor
@@ -3,14 +3,14 @@
 function shutdown()
 {
     echo "`date +"%d.%m.%Y %T.%3N"` - Shutting down mysql"
-    /etc/init.d/mysql stop
+    /etc/init.d/mariadb stop
 }
 
 echo "`date +"%d.%m.%Y %T.%3N"` - Starting mysql"
 
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 # Allow any signal which would kill a process to stop server
 trap shutdown HUP INT QUIT ABRT KILL ALRM TERM TSTP
 
-while pgrep -u mysql mysql > /dev/null; do sleep 5; done
+while pgrep -u mysql mariadb > /dev/null; do sleep 5; done


### PR DESCRIPTION
Upgrade Rundeck to 3.4.0  
Upgrade rundeck-cli to 1.3.10  

Upgrade MariaDB to 10.5 to avoid error "Specified key was too long; max key length is 767 bytes"  
[_MySQL 5.6 no longer supported_ ](https://docs.rundeck.com/docs/history/3_4_x/version-3.4.0.html#upgrading-to-3-4-0-notes) 
I also tried with MariaDB 10.2 and it works as well, it doesn't need the change from /etc/init.d/mysql to /etc/init.d/mariadb though.
I will let you decide whether to install 10.2 or 10.5.

I only tested this as a new installation, I didn't try it yet at work.