### PR TITLE
Upgrade 3.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=10.5 && \
     apt-get -qqy install -t stretch-backports --no-install-recommends bash openjdk-8-jre-headless ca-certificates-java supervisor procps sudo openssh-client mariadb-server mariadb-client postgresql-9.6 postgresql-client-9.6 pwgen git uuid-runtime parallel jq && \
     cd /tmp/ && \
-    curl -Lo /tmp/rundeck.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck_3.4.6.20211110-1_all.deb/download.deb && \
-    echo '6c7adb218e9813c9ee3f121c8b3ba0e447bc8fff0652f8d7a686c8df25b9f2f3  rundeck.deb' > /tmp/rundeck.sig && \
+    curl -Lo /tmp/rundeck.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck_3.4.7.20211210-1_all.deb/download.deb && \
+    echo 'c4c8577d9de87f20ce9aab7da34c24bdc6a347ecc98595ad57606e57b6374114  rundeck.deb' > /tmp/rundeck.sig && \
     shasum -a256 -c /tmp/rundeck.sig && \
     curl -Lo /tmp/rundeck-cli.deb https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck-cli_1.3.10-1_all.deb/download.deb && \
     echo 'e9f6fb2cd051b32b452a055ce5aa7e354b21e011a9c00c76e3d624c2338a3736  rundeck-cli.deb' > /tmp/rundeck-cli.sig && \


### PR DESCRIPTION
[[This release includes updated packages to address the recent Log4j vulnerability. For more information check out our Log4j Security page.](https://docs.rundeck.com/docs/history/3_4_x/version-3.4.7.html#overview)](https://docs.rundeck.com/docs/history/3_4_x/version-3.4.7.html#overview)