### PR TITLE
Update repo quicksetup URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qqy install -t bullseye-backports --no-install-recommends apt-transport-https curl ca-certificates && \
     curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=10.5 && \
     apt-get -qqy install -t bullseye-backports --no-install-recommends bash openjdk-11-jre-headless ca-certificates-java supervisor procps sudo openssh-client mariadb-server mariadb-client postgresql postgresql-client pwgen git uuid-runtime parallel jq libxml2-utils html2text unzip && \
-    curl -s https://packagecloud.io/install/repositories/pagerduty/rundeck/script.deb.sh | os=any dist=any bash && \
+    curl -s https://raw.githubusercontent.com/rundeck/packaging/main/scripts/deb-setup.sh 2> /dev/null | bash -s rundeck && \
     apt-get -qqy install rundeck rundeck-cli && \
     mkdir -p /tmp/rundeck && \
     chown rundeck:rundeck /tmp/rundeck && \


### PR DESCRIPTION
The rundeck [apt repo quicksetup script](https://packagecloud.io/install/repositories/pagerduty/rundeck/script.deb.sh) is updated, and it's changed to use from [rundeck official Github repository](https://raw.githubusercontent.com/rundeck/packaging/main/scripts/deb-setup.sh). Any docker build from old URL will failed due to irrelevant of old apt repo. The error is when `apt` try to update, you'll find this kind of output.
```
root@39030adb20d8:/# apt-get update
Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
Ign:5 https://packagecloud.io/pagerduty/rundeck/ubuntu bionic InRelease
Err:6 https://packagecloud.io/pagerduty/rundeck/ubuntu bionic Release
  404  Not Found [IP: 54.183.38.243 443]
Reading package lists... Done
E: The repository 'https://packagecloud.io/pagerduty/rundeck/ubuntu bionic Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

The apt repo itself is moved
```
From:
https://packagecloud.io/pagerduty/rundeck/

To:
https://packages.rundeck.com/pagerduty/rundeck/
```


Refs:
https://github.com/rundeck/rundeck/issues/7098
https://docs.rundeck.com/docs/administration/install/linux-deb.html#installing-rundeck